### PR TITLE
Fix appveyor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![appveyor build](https://ci.appveyor.com/api/projects/status/github/bitwarden/core?branch=master&svg=true)] (https://ci.appveyor.com/project/bitwarden/core)
+[![appveyor build](https://ci.appveyor.com/api/projects/status/github/bitwarden/core?branch=master&svg=true)](https://ci.appveyor.com/project/bitwarden/core/branch/master)
 [![Join the chat at https://gitter.im/bitwarden/Lobby](https://badges.gitter.im/bitwarden/Lobby.svg)](https://gitter.im/bitwarden/Lobby)
 
 # bitwarden Core


### PR DESCRIPTION
A slight syntax error on the appveyor badge was causing the markdown not to
display and link correctly. In addition, this commit ensures that the appveyor
badge links to the builds that it is representing and not all builds for the
project.