### PR TITLE
Remove -t from docker run commands

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -53,27 +53,27 @@ function updateLetsEncrypt() {
     if [ -d "${OUTPUT_DIR}/letsencrypt/live" ]
     then
         docker pull certbot/certbot
-        docker run -it --rm --name certbot -p 443:443 -p 80:80 -v $OUTPUT_DIR/letsencrypt:/etc/letsencrypt/ certbot/certbot \
+        docker run -i --rm --name certbot -p 443:443 -p 80:80 -v $OUTPUT_DIR/letsencrypt:/etc/letsencrypt/ certbot/certbot \
             renew --logs-dir /etc/letsencrypt/logs
     fi
 }
 
 function updateDatabase() {
     pullSetup
-    docker run -it --rm --name setup --network container:bitwarden-mssql -v $OUTPUT_DIR:/bitwarden bitwarden/setup:$COREVERSION \
+    docker run -i --rm --name setup --network container:bitwarden-mssql -v $OUTPUT_DIR:/bitwarden bitwarden/setup:$COREVERSION \
         dotnet Setup.dll -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
     echo "Database update complete"
 }
 
 function update() {
     pullSetup
-    docker run -it --rm --name setup -v $OUTPUT_DIR:/bitwarden bitwarden/setup:$COREVERSION \
+    docker run -i --rm --name setup -v $OUTPUT_DIR:/bitwarden bitwarden/setup:$COREVERSION \
         dotnet Setup.dll -update 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
 }
 
 function printEnvironment() {
     pullSetup
-    docker run -it --rm --name setup -v $OUTPUT_DIR:/bitwarden bitwarden/setup:$COREVERSION \
+    docker run -i --rm --name setup -v $OUTPUT_DIR:/bitwarden bitwarden/setup:$COREVERSION \
         dotnet Setup.dll -printenv 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
 }
 


### PR DESCRIPTION
Allows running the update commands from cron without getting the TTY error listed in https://github.com/bitwarden/core/issues/180

Given what happens when each of these docker run commands execute, it seems like the -t flag is unnecessary.  Nothing requires interaction from the user in these cases.  Based on this helpful explanation of the -i and -t flags for docker run:  https://gist.github.com/v0lkan/c413cf9477b607db1ea1117c9de853df

I'm thinking the -t flag is really only necessary for the install.sh script (e.g., port numbers, cert, etc.).