### PR TITLE
Removed -f from docker-compose command

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -34,15 +34,15 @@ DOCKER_DIR="$OUTPUT_DIR/docker"
 # Functions
 
 function dockerComposeUp() {
-    docker-compose -f $DOCKER_DIR/docker-compose.yml up -d
+    docker-compose $DOCKER_DIR/docker-compose.yml up -d
 }
 
 function dockerComposeDown() {
-    docker-compose -f $DOCKER_DIR/docker-compose.yml down
+    docker-compose $DOCKER_DIR/docker-compose.yml down
 }
 
 function dockerComposePull() {
-    docker-compose -f $DOCKER_DIR/docker-compose.yml pull
+    docker-compose $DOCKER_DIR/docker-compose.yml pull
 }
 
 function dockerPrune() {


### PR DESCRIPTION
In the event a user would, like me, ovveride some config in a docker-compose.override.yml, I remove the -f so that docker-compose will, by default, look for a docker-compose.yml file and an override file named docker-compose.override.yml. This way an advanced user can, by creating the override file, update and extend any config already present in the docker-compose.yml file.
This is particularly useful when you have to set CPU/RAM reqs on containers or change network configuration to have isolated networks,.etc...