### PR TITLE
Allow usage of default override file

### DIFF
--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -17,15 +17,15 @@ $dockerDir="${outputDir}\docker"
 # Functions
 
 function Docker-Compose-Up {
-    docker-compose -f ${dockerDir}\docker-compose.yml up -d
+    docker-compose -f ${dockerDir}\docker-compose.yml -f ${dockerDir}\docker-compose.override.yml up -d
 }
 
 function Docker-Compose-Down {
-    docker-compose -f ${dockerDir}\docker-compose.yml down
+    docker-compose -f ${dockerDir}\docker-compose.yml -f ${dockerDir}\docker-compose.override.yml down
 }
 
 function Docker-Compose-Pull {
-    docker-compose -f ${dockerDir}\docker-compose.yml pull
+    docker-compose -f ${dockerDir}\docker-compose.yml -f ${dockerDir}\docker-compose.override.yml pull
 }
 
 function Docker-Prune {

--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -17,15 +17,31 @@ $dockerDir="${outputDir}\docker"
 # Functions
 
 function Docker-Compose-Up {
-    docker-compose -f ${dockerDir}\docker-compose.yml -f ${dockerDir}\docker-compose.override.yml up -d
+    if(Test-Path -Path "${dockerDir}\docker-compose.override.yml" -PathType leaf) {
+        docker-compose -f ${dockerDir}\docker-compose.yml -f ${dockerDir}\docker-compose.override.yml up -d
+    }
+    else {
+        docker-compose -f ${dockerDir}\docker-compose.yml up -d
+    }
 }
 
 function Docker-Compose-Down {
-    docker-compose -f ${dockerDir}\docker-compose.yml -f ${dockerDir}\docker-compose.override.yml down
+    if(Test-Path -Path "${dockerDir}\docker-compose.override.yml" -PathType leaf) {
+        docker-compose -f ${dockerDir}\docker-compose.yml -f ${dockerDir}\docker-compose.override.yml down
+    }
+    else {
+        docker-compose -f ${dockerDir}\docker-compose.yml down
+    }
 }
 
 function Docker-Compose-Pull {
-    docker-compose -f ${dockerDir}\docker-compose.yml -f ${dockerDir}\docker-compose.override.yml pull
+    if(Test-Path -Path "${dockerDir}\docker-compose.override.yml" -PathType leaf) {
+        docker-compose -f ${dockerDir}\docker-compose.yml -f ${dockerDir}\docker-compose.override.yml pull
+    }
+    else {
+        docker-compose -f ${dockerDir}\docker-compose.yml pull
+    }
+    
 }
 
 function Docker-Prune {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -34,15 +34,15 @@ DOCKER_DIR="$OUTPUT_DIR/docker"
 # Functions
 
 function dockerComposeUp() {
-    docker-compose -f $DOCKER_DIR/docker-compose.yml up -d
+    docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml up -d
 }
 
 function dockerComposeDown() {
-    docker-compose -f $DOCKER_DIR/docker-compose.yml down
+    docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml down
 }
 
 function dockerComposePull() {
-    docker-compose -f $DOCKER_DIR/docker-compose.yml pull
+    docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml pull
 }
 
 function dockerPrune() {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -34,15 +34,30 @@ DOCKER_DIR="$OUTPUT_DIR/docker"
 # Functions
 
 function dockerComposeUp() {
-    docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml up -d
+    if [ -f "$DOCKER_DIR/docker-compose.override.yml" ]
+    then
+        docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml up -d
+    else
+        docker-compose -f $DOCKER_DIR/docker-compose.yml up -d
+    fi
 }
 
 function dockerComposeDown() {
-    docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml down
+    if [ -f "$DOCKER_DIR/docker-compose.override.yml" ]
+    then
+        docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml down
+    else
+        docker-compose -f $DOCKER_DIR/docker-compose.yml down
+    fi
 }
 
 function dockerComposePull() {
-    docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml pull
+    if [ -f "$DOCKER_DIR/docker-compose.override.yml" ]
+    then
+        docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml pull
+    else
+        docker-compose -f $DOCKER_DIR/docker-compose.yml pull
+    fi
 }
 
 function dockerPrune() {


### PR DESCRIPTION
To adapt bitwarden runtime to a specific environment (network, resources,...) we need to support override file (at least, the default one) so that user can extend some settings from the bitwarden default.

Ie. Have it running in an isolated network zone, named differently from "docker_default", adapt CPU/RAM reservation/capping,...

Compose files are read from left -f argument to right with the last one possibly overriding settings from the first one. See: https://docs.docker.com/compose/extends/ for info