### PR TITLE
Use user primary group if not root

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,7 +29,7 @@ then
 fi
 
 LUID="LOCAL_UID=`id -u $USER`"
-if [ `id -u $USER` -eq 0 ]
+if [ "$OS" == "lin" -a `id -u $USER` -eq 0 ]
 then
     LGID="LOCAL_GID=`getent group docker | cut -d: -f3`"
 else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,7 +29,12 @@ then
 fi
 
 LUID="LOCAL_UID=`id -u $USER`"
-LGID="LOCAL_GID=`getent group docker | cut -d: -f3`"
+if [ `id -u $USER` -eq 0 ]
+then
+    LGID="LOCAL_GID=`getent group docker | cut -d: -f3`"
+else
+    LGID="LOCAL_GID=`id -g $USER`"
+fi
 
 mkdir -p $OUTPUT_DIR
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -32,7 +32,12 @@ fi
 DOCKER_DIR="$OUTPUT_DIR/docker"
 ENV_DIR="$OUTPUT_DIR/env"
 LUID="LOCAL_UID=`id -u $USER`"
-LGID="LOCAL_GID=`getent group docker | cut -d: -f3`"
+if [ `id -u $USER` -eq 0 ]
+then
+    LGID="LOCAL_GID=`getent group docker | cut -d: -f3`"
+else
+    LGID="LOCAL_GID=`id -g $USER`"
+fi
 
 # Functions
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -5,7 +5,7 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-OUTPUT_DIR="../."
+OUTPUT_DIR=".."
 if [ $# -gt 1 ]
 then
     OUTPUT_DIR=$2
@@ -23,21 +23,8 @@ then
     WEBVERSION=$4
 fi
 
-OS="lin"
-if [ "$(uname)" == "Darwin" ]
-then
-    OS="mac"
-fi
-
-DOCKER_DIR="$OUTPUT_DIR/docker"
 ENV_DIR="$OUTPUT_DIR/env"
-LUID="LOCAL_UID=`id -u $USER`"
-if [ "$OS" == "lin" -a `id -u $USER` -eq 0 ]
-then
-    LGID="LOCAL_GID=`getent group docker | cut -d: -f3`"
-else
-    LGID="LOCAL_GID=`id -g $USER`"
-fi
+DOCKER_DIR="$OUTPUT_DIR/docker"
 
 # Functions
 
@@ -84,58 +71,30 @@ function updateLetsEncrypt() {
 
 function updateDatabase() {
     pullSetup
-    if [ $OS == "lin" ]
-    then
-        docker run -i --rm --name setup --network container:bitwarden-mssql \
-            -v $OUTPUT_DIR:/bitwarden -e $LUID -e $LGID bitwarden/setup:$COREVERSION \
-            dotnet Setup.dll -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
-    else
-        docker run -i --rm --name setup --network container:bitwarden-mssql \
-            -v $OUTPUT_DIR:/bitwarden bitwarden/setup:$COREVERSION \
-            dotnet Setup.dll -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
-    fi
+    docker run -i --rm --name setup --network container:bitwarden-mssql \
+        -v $OUTPUT_DIR:/bitwarden --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
+        dotnet Setup.dll -update 1 -db 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
     echo "Database update complete"
 }
 
 function update() {
     pullSetup
-    if [ $OS == "lin" ]
-    then
-        docker run -i --rm --name setup -v $OUTPUT_DIR:/bitwarden \
-            -e $LUID -e $LGID bitwarden/setup:$COREVERSION \
-            dotnet Setup.dll -update 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
-    else
-        docker run -i --rm --name setup \
-            -v $OUTPUT_DIR:/bitwarden bitwarden/setup:$COREVERSION \
-            dotnet Setup.dll -update 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
-    fi
+    docker run -i --rm --name setup -v $OUTPUT_DIR:/bitwarden \
+        --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
+        dotnet Setup.dll -update 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
 }
 
 function printEnvironment() {
     pullSetup
-    if [ $OS == "lin" ]
-    then
-        docker run -i --rm --name setup -v $OUTPUT_DIR:/bitwarden \
-            -e $LUID -e $LGID bitwarden/setup:$COREVERSION \
-            dotnet Setup.dll -printenv 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
-    else
-        docker run -i --rm --name setup \
-            -v $OUTPUT_DIR:/bitwarden bitwarden/setup:$COREVERSION \
-            dotnet Setup.dll -printenv 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
-    fi
+    docker run -i --rm --name setup -v $OUTPUT_DIR:/bitwarden \
+        --env-file $ENV_DIR/uid.env bitwarden/setup:$COREVERSION \
+        dotnet Setup.dll -printenv 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
 }
 
 function restart() {
     dockerComposeDown
     dockerComposePull
     updateLetsEncrypt
-    
-    if [ $OS == "lin" ]
-    then
-        mkdir -p $ENV_DIR
-        (echo $LUID; echo $LGID) > $ENV_DIR/uid.env
-    fi
-    
     dockerComposeUp
     dockerPrune
     printEnvironment

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -27,7 +27,7 @@ ENV_DIR="$OUTPUT_DIR/env"
 DOCKER_DIR="$OUTPUT_DIR/docker"
 
 # As in install.sh, save the running UID/GID, they could not exist yet, during an update for example
-if [ ! -f $ENV_DIR/uid.env ]
+if ! grep -q "^LOCAL_UID=" $ENV_DIR/uid.env 2>/dev/null || ! grep -q "^LOCAL_GID=" $ENV_DIR/uid.env 2>/dev/null
 then
     LUID="LOCAL_UID=`id -u $USER`"
     LGID="LOCAL_GID=`id -g $USER`"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -26,6 +26,15 @@ fi
 ENV_DIR="$OUTPUT_DIR/env"
 DOCKER_DIR="$OUTPUT_DIR/docker"
 
+# As in install.sh, save the running UID/GID, they could not exist yet, during an update for example
+if [ ! -f $ENV_DIR/uid.env ]
+then
+    LUID="LOCAL_UID=`id -u $USER`"
+    LGID="LOCAL_GID=`id -g $USER`"
+    mkdir -p $ENV_DIR
+    (echo $LUID; echo $LGID) > $ENV_DIR/uid.env
+fi
+
 # Functions
 
 function dockerComposeUp() {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -32,7 +32,7 @@ fi
 DOCKER_DIR="$OUTPUT_DIR/docker"
 ENV_DIR="$OUTPUT_DIR/env"
 LUID="LOCAL_UID=`id -u $USER`"
-if [ `id -u $USER` -eq 0 ]
+if [ "$OS" == "lin" -a `id -u $USER` -eq 0 ]
 then
     LGID="LOCAL_GID=`getent group docker | cut -d: -f3`"
 else

--- a/src/Admin/entrypoint.sh
+++ b/src/Admin/entrypoint.sh
@@ -5,52 +5,27 @@
 GROUPNAME="bitwarden"
 USERNAME="bitwarden"
 
-CURRENTGID=`getent group $GROUPNAME | cut -d: -f3`
-LGID=${LOCAL_GID:-999}
+LUID=${LOCAL_UID:-0}
+LGID=${LOCAL_GID:-0}
 
-NOUSER=`id -u $USERNAME > /dev/null 2>&1; echo $?`
-LUID=${LOCAL_UID:-999}
+# Step down from host root to well-known nobody/nogroup user
 
-# Step down from host root
-
-if [ $LGID == 0 ]
+if [ $LUID -eq 0 ]
 then
-    LGID=999
+    LUID=65534
+fi
+if [ $LGID -eq 0 ]
+then
+    LGID=65534
 fi
 
-if [ $LUID == 0 ]
-then
-    LUID=999
-fi
+# Create user and group
 
-# Create group
-
-if [ $CURRENTGID ]
-then
-    if [ "$CURRENTGID" != "$LGID" ]
-    then
-        groupmod -g $LGID $GROUPNAME
-    fi
-else
-    groupadd -g $LGID $GROUPNAME
-fi
-
-# Create user and assign group
-
-if [ $NOUSER == 0 ] && [ `id -u $USERNAME` != $LUID ]
-then
-    usermod -u $LUID $USERNAME
-elif [ $NOUSER == 1 ]
-then
-    useradd -r -u $LUID -g $GROUPNAME $USERNAME
-fi
-
-# Make home directory for user
-
-if [ ! -d "/home/$USERNAME" ]
-then
-    mkhomedir_helper $USERNAME
-fi
+groupadd -o -g $LGID $GROUPNAME >/dev/null 2>&1 ||
+groupmod -o -g $LGID $GROUPNAME >/dev/null 2>&1
+useradd -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1 ||
+usermod -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1
+mkhomedir_helper $USERNAME
 
 # The rest...
 
@@ -63,4 +38,4 @@ chown -R $USERNAME:$GROUPNAME /etc/bitwarden
 cp /etc/bitwarden/ca-certificates/*.crt /usr/local/share/ca-certificates/ \
     && update-ca-certificates
 
-gosu $USERNAME:$GROUPNAME dotnet /app/Admin.dll
+exec gosu $USERNAME:$GROUPNAME dotnet /app/Admin.dll

--- a/src/Api/entrypoint.sh
+++ b/src/Api/entrypoint.sh
@@ -5,52 +5,27 @@
 GROUPNAME="bitwarden"
 USERNAME="bitwarden"
 
-CURRENTGID=`getent group $GROUPNAME | cut -d: -f3`
-LGID=${LOCAL_GID:-999}
+LUID=${LOCAL_UID:-0}
+LGID=${LOCAL_GID:-0}
 
-NOUSER=`id -u $USERNAME > /dev/null 2>&1; echo $?`
-LUID=${LOCAL_UID:-999}
+# Step down from host root to well-known nobody/nogroup user
 
-# Step down from host root
-
-if [ $LGID == 0 ]
+if [ $LUID -eq 0 ]
 then
-    LGID=999
+    LUID=65534
+fi
+if [ $LGID -eq 0 ]
+then
+    LGID=65534
 fi
 
-if [ $LUID == 0 ]
-then
-    LUID=999
-fi
+# Create user and group
 
-# Create group
-
-if [ $CURRENTGID ]
-then
-    if [ "$CURRENTGID" != "$LGID" ]
-    then
-        groupmod -g $LGID $GROUPNAME
-    fi
-else
-    groupadd -g $LGID $GROUPNAME
-fi
-
-# Create user and assign group
-
-if [ $NOUSER == 0 ] && [ `id -u $USERNAME` != $LUID ]
-then
-    usermod -u $LUID $USERNAME
-elif [ $NOUSER == 1 ]
-then
-    useradd -r -u $LUID -g $GROUPNAME $USERNAME
-fi
-
-# Make home directory for user
-
-if [ ! -d "/home/$USERNAME" ]
-then
-    mkhomedir_helper $USERNAME
-fi
+groupadd -o -g $LGID $GROUPNAME >/dev/null 2>&1 ||
+groupmod -o -g $LGID $GROUPNAME >/dev/null 2>&1
+useradd -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1 ||
+usermod -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1
+mkhomedir_helper $USERNAME
 
 # The rest...
 
@@ -63,10 +38,11 @@ mkdir -p /etc/bitwarden/logs
 mkdir -p /etc/bitwarden/ca-certificates
 chown -R $USERNAME:$GROUPNAME /etc/bitwarden
 
-env >> /etc/environment
+# Sounds like gosu keeps env when switching, but of course cron does not
+env > /etc/environment
 cron
 
 cp /etc/bitwarden/ca-certificates/*.crt /usr/local/share/ca-certificates/ \
     && update-ca-certificates
 
-gosu $USERNAME:$GROUPNAME dotnet /app/Api.dll
+exec gosu $USERNAME:$GROUPNAME dotnet /app/Api.dll

--- a/src/Icons/entrypoint.sh
+++ b/src/Icons/entrypoint.sh
@@ -5,52 +5,27 @@
 GROUPNAME="bitwarden"
 USERNAME="bitwarden"
 
-CURRENTGID=`getent group $GROUPNAME | cut -d: -f3`
-LGID=${LOCAL_GID:-999}
+LUID=${LOCAL_UID:-0}
+LGID=${LOCAL_GID:-0}
 
-NOUSER=`id -u $USERNAME > /dev/null 2>&1; echo $?`
-LUID=${LOCAL_UID:-999}
+# Step down from host root to well-known nobody/nogroup user
 
-# Step down from host root
-
-if [ $LGID == 0 ]
+if [ $LUID -eq 0 ]
 then
-    LGID=999
+    LUID=65534
+fi
+if [ $LGID -eq 0 ]
+then
+    LGID=65534
 fi
 
-if [ $LUID == 0 ]
-then
-    LUID=999
-fi
+# Create user and group
 
-# Create group
-
-if [ $CURRENTGID ]
-then
-    if [ "$CURRENTGID" != "$LGID" ]
-    then
-        groupmod -g $LGID $GROUPNAME
-    fi
-else
-    groupadd -g $LGID $GROUPNAME
-fi
-
-# Create user and assign group
-
-if [ $NOUSER == 0 ] && [ `id -u $USERNAME` != $LUID ]
-then
-    usermod -u $LUID $USERNAME
-elif [ $NOUSER == 1 ]
-then
-    useradd -r -u $LUID -g $GROUPNAME $USERNAME
-fi
-
-# Make home directory for user
-
-if [ ! -d "/home/$USERNAME" ]
-then
-    mkhomedir_helper $USERNAME
-fi
+groupadd -o -g $LGID $GROUPNAME >/dev/null 2>&1 ||
+groupmod -o -g $LGID $GROUPNAME >/dev/null 2>&1
+useradd -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1 ||
+usermod -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1
+mkhomedir_helper $USERNAME
 
 # The rest...
 
@@ -58,4 +33,4 @@ chown -R $USERNAME:$GROUPNAME /app
 chown -R $USERNAME:$GROUPNAME /etc/iconserver
 
 gosu $USERNAME:$GROUPNAME /etc/iconserver/iconserver &
-gosu $USERNAME:$GROUPNAME dotnet /app/Icons.dll iconsSettings:bestIconBaseUrl=http://localhost:8080
+exec gosu $USERNAME:$GROUPNAME dotnet /app/Icons.dll iconsSettings:bestIconBaseUrl=http://localhost:8080

--- a/src/Identity/entrypoint.sh
+++ b/src/Identity/entrypoint.sh
@@ -5,52 +5,27 @@
 GROUPNAME="bitwarden"
 USERNAME="bitwarden"
 
-CURRENTGID=`getent group $GROUPNAME | cut -d: -f3`
-LGID=${LOCAL_GID:-999}
+LUID=${LOCAL_UID:-0}
+LGID=${LOCAL_GID:-0}
 
-NOUSER=`id -u $USERNAME > /dev/null 2>&1; echo $?`
-LUID=${LOCAL_UID:-999}
+# Step down from host root to well-known nobody/nogroup user
 
-# Step down from host root
-
-if [ $LGID == 0 ]
+if [ $LUID -eq 0 ]
 then
-    LGID=999
+    LUID=65534
+fi
+if [ $LGID -eq 0 ]
+then
+    LGID=65534
 fi
 
-if [ $LUID == 0 ]
-then
-    LUID=999
-fi
+# Create user and group
 
-# Create group
-
-if [ $CURRENTGID ]
-then
-    if [ "$CURRENTGID" != "$LGID" ]
-    then
-        groupmod -g $LGID $GROUPNAME
-    fi
-else
-    groupadd -g $LGID $GROUPNAME
-fi
-
-# Create user and assign group
-
-if [ $NOUSER == 0 ] && [ `id -u $USERNAME` != $LUID ]
-then
-    usermod -u $LUID $USERNAME
-elif [ $NOUSER == 1 ]
-then
-    useradd -r -u $LUID -g $GROUPNAME $USERNAME
-fi
-
-# Make home directory for user
-
-if [ ! -d "/home/$USERNAME" ]
-then
-    mkhomedir_helper $USERNAME
-fi
+groupadd -o -g $LGID $GROUPNAME >/dev/null 2>&1 ||
+groupmod -o -g $LGID $GROUPNAME >/dev/null 2>&1
+useradd -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1 ||
+usermod -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1
+mkhomedir_helper $USERNAME
 
 # The rest...
 
@@ -66,4 +41,4 @@ chown -R $USERNAME:$GROUPNAME /app
 cp /etc/bitwarden/ca-certificates/*.crt /usr/local/share/ca-certificates/ \
     && update-ca-certificates
 
-gosu $USERNAME:$GROUPNAME dotnet /app/Identity.dll
+exec gosu $USERNAME:$GROUPNAME dotnet /app/Identity.dll

--- a/util/MsSql/entrypoint.sh
+++ b/util/MsSql/entrypoint.sh
@@ -5,52 +5,27 @@
 GROUPNAME="bitwarden"
 USERNAME="bitwarden"
 
-CURRENTGID=`getent group $GROUPNAME | cut -d: -f3`
-LGID=${LOCAL_GID:-999}
+LUID=${LOCAL_UID:-0}
+LGID=${LOCAL_GID:-0}
 
-NOUSER=`id -u $USERNAME > /dev/null 2>&1; echo $?`
-LUID=${LOCAL_UID:-999}
+# Step down from host root to well-known nobody/nogroup user
 
-# Step down from host root
-
-if [ $LGID == 0 ]
+if [ $LUID -eq 0 ]
 then
-    LGID=999
+    LUID=65534
+fi
+if [ $LGID -eq 0 ]
+then
+    LGID=65534
 fi
 
-if [ $LUID == 0 ]
-then
-    LUID=999
-fi
+# Create user and group
 
-# Create group
-
-if [ $CURRENTGID ]
-then
-    if [ "$CURRENTGID" != "$LGID" ]
-    then
-        groupmod -g $LGID $GROUPNAME
-    fi
-else
-    groupadd -g $LGID $GROUPNAME
-fi
-
-# Create user and assign group
-
-if [ $NOUSER == 0 ] && [ `id -u $USERNAME` != $LUID ]
-then
-    usermod -u $LUID $USERNAME
-elif [ $NOUSER == 1 ]
-then
-    useradd -r -u $LUID -g $GROUPNAME $USERNAME
-fi
-
-# Make home directory for user
-
-if [ ! -d "/home/$USERNAME" ]
-then
-    mkhomedir_helper $USERNAME
-fi
+groupadd -o -g $LGID $GROUPNAME >/dev/null 2>&1 ||
+groupmod -o -g $LGID $GROUPNAME >/dev/null 2>&1
+useradd -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1 ||
+usermod -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1
+mkhomedir_helper $USERNAME
 
 # The rest...
 
@@ -63,7 +38,8 @@ chown -R $USERNAME:$GROUPNAME /var/opt/mssql
 chown $USERNAME:$GROUPNAME /backup-db.sh
 chown $USERNAME:$GROUPNAME /backup-db.sql
 
-env >> /etc/environment
+# Sounds like gosu keeps env when switching, but of course cron does not
+env > /etc/environment
 cron
 
-gosu $USERNAME:$GROUPNAME /opt/mssql/bin/sqlservr
+exec gosu $USERNAME:$GROUPNAME /opt/mssql/bin/sqlservr

--- a/util/Nginx/entrypoint.sh
+++ b/util/Nginx/entrypoint.sh
@@ -5,52 +5,27 @@
 GROUPNAME="bitwarden"
 USERNAME="bitwarden"
 
-CURRENTGID=`getent group $GROUPNAME | cut -d: -f3`
-LGID=${LOCAL_GID:-999}
+LUID=${LOCAL_UID:-0}
+LGID=${LOCAL_GID:-0}
 
-NOUSER=`id -u $USERNAME > /dev/null 2>&1; echo $?`
-LUID=${LOCAL_UID:-999}
+# Step down from host root to well-known nobody/nogroup user
 
-# Step down from host root
-
-if [ $LGID == 0 ]
+if [ $LUID -eq 0 ]
 then
-    LGID=999
+    LUID=65534
+fi
+if [ $LGID -eq 0 ]
+then
+    LGID=65534
 fi
 
-if [ $LUID == 0 ]
-then
-    LUID=999
-fi
+# Create user and group
 
-# Create group
-
-if [ $CURRENTGID ]
-then
-    if [ "$CURRENTGID" != "$LGID" ]
-    then
-        groupmod -g $LGID $GROUPNAME
-    fi
-else
-    groupadd -g $LGID $GROUPNAME
-fi
-
-# Create user and assign group
-
-if [ $NOUSER == 0 ] && [ `id -u $USERNAME` != $LUID ]
-then
-    usermod -u $LUID $USERNAME
-elif [ $NOUSER == 1 ]
-then
-    useradd -r -u $LUID -g $GROUPNAME $USERNAME
-fi
-
-# Make home directory for user
-
-if [ ! -d "/home/$USERNAME" ]
-then
-    mkhomedir_helper $USERNAME
-fi
+groupadd -o -g $LGID $GROUPNAME >/dev/null 2>&1 ||
+groupmod -o -g $LGID $GROUPNAME >/dev/null 2>&1
+useradd -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1 ||
+usermod -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1
+mkhomedir_helper $USERNAME
 
 # The rest...
 
@@ -65,4 +40,4 @@ chown -R $USERNAME:$GROUPNAME /var/run/nginx.pid
 chown -R $USERNAME:$GROUPNAME /var/cache/nginx
 chown -R $USERNAME:$GROUPNAME /var/log/nginx
 
-gosu $USERNAME:$GROUPNAME nginx -g 'daemon off;'
+exec gosu $USERNAME:$GROUPNAME nginx -g 'daemon off;'

--- a/util/Setup/EnvironmentFileBuilder.cs
+++ b/util/Setup/EnvironmentFileBuilder.cs
@@ -172,7 +172,10 @@ SA_PASSWORD=SECRET
             Helpers.Exec("chmod 600 /bitwarden/env/mssql.override.env");
 
             // Empty uid env file. Only used on Linux hosts.
-            using(var sw = File.CreateText("/bitwarden/env/uid.env")) { }
+            if(!File.Exists("/bitwarden/env/uid.env"))
+            {
+                using(var sw = File.CreateText("/bitwarden/env/uid.env")) { }
+            }
         }
     }
 }

--- a/util/Setup/entrypoint.sh
+++ b/util/Setup/entrypoint.sh
@@ -5,52 +5,27 @@
 GROUPNAME="bitwarden"
 USERNAME="bitwarden"
 
-CURRENTGID=`getent group $GROUPNAME | cut -d: -f3`
-LGID=${LOCAL_GID:-999}
+LUID=${LOCAL_UID:-0}
+LGID=${LOCAL_GID:-0}
 
-NOUSER=`id -u $USERNAME > /dev/null 2>&1; echo $?`
-LUID=${LOCAL_UID:-999}
+# Step down from host root to well-known nobody/nogroup user
 
-# Step down from host root
-
-if [ $LGID == 0 ]
+if [ $LUID -eq 0 ]
 then
-    LGID=999
+    LUID=65534
+fi
+if [ $LGID -eq 0 ]
+then
+    LGID=65534
 fi
 
-if [ $LUID == 0 ]
-then
-    LUID=999
-fi
+# Create user and group
 
-# Create group
-
-if [ $CURRENTGID ]
-then
-    if [ "$CURRENTGID" != "$LGID" ]
-    then
-        groupmod -g $LGID $GROUPNAME
-    fi
-else
-    groupadd -g $LGID $GROUPNAME
-fi
-
-# Create user and assign group
-
-if [ $NOUSER == 0 ] && [ `id -u $USERNAME` != $LUID ]
-then
-    usermod -u $LUID $USERNAME
-elif [ $NOUSER == 1 ]
-then
-    useradd -r -u $LUID -g $GROUPNAME $USERNAME
-fi
-
-# Make home directory for user
-
-if [ ! -d "/home/$USERNAME" ]
-then
-    mkhomedir_helper $USERNAME
-fi
+groupadd -o -g $LGID $GROUPNAME >/dev/null 2>&1 ||
+groupmod -o -g $LGID $GROUPNAME >/dev/null 2>&1
+useradd -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1 ||
+usermod -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1
+mkhomedir_helper $USERNAME
 
 # The rest...
 


### PR DESCRIPTION
Hi,

This PR modifies startup scripts so that when Bitwarden is started from a user which is not `root`, the group used to launch the services is the user's group, rather than the "default" `docker` group.
This is what we expect on system side.

`docker` group remains the chosen group if Bitwarden is launched from `root` account.

Thank you !