### PR TITLE
Workaround to disable mssql telemetry

### DIFF
--- a/util/MsSql/entrypoint.sh
+++ b/util/MsSql/entrypoint.sh
@@ -66,4 +66,9 @@ chown $USERNAME:$GROUPNAME /backup-db.sql
 env >> /etc/environment
 cron
 
+# Workaround to disable mssql telemetry
+
+echo "127.0.0.1 settings-win.data.microsoft.com" >> /etc/hosts
+echo "127.0.0.1 vortex.data.microsoft.com" >> /etc/hosts
+
 gosu $USERNAME:$GROUPNAME /opt/mssql/bin/sqlservr


### PR DESCRIPTION
Hi,

This PR is a workaround for #286, until an official solution is found.

It forbids mssql to reach the 2 domains it sends telemetry data to.

Thank you !