### PR TITLE
Workaround to disable mssql telemetry in DockerFile

### DIFF
--- a/util/MsSql/Dockerfile
+++ b/util/MsSql/Dockerfile
@@ -16,5 +16,8 @@ RUN chmod +x /entrypoint.sh \
     && chmod +x /backup-db.sh
 
 RUN /opt/mssql/bin/mssql-conf set telemetry.customerfeedback false
+# As the setting above does not work, let's use the workaround below
+RUN echo 127.0.0.1 settings-win.data.microsoft.com >> /etc/hosts
+RUN echo 127.0.0.1 vortex.data.microsoft.com >> /etc/hosts
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/util/MsSql/entrypoint.sh
+++ b/util/MsSql/entrypoint.sh
@@ -66,9 +66,4 @@ chown $USERNAME:$GROUPNAME /backup-db.sql
 env >> /etc/environment
 cron
 
-# Workaround to disable mssql telemetry
-
-echo "127.0.0.1 settings-win.data.microsoft.com" >> /etc/hosts
-echo "127.0.0.1 vortex.data.microsoft.com" >> /etc/hosts
-
 gosu $USERNAME:$GROUPNAME /opt/mssql/bin/sqlservr


### PR DESCRIPTION
Hi,

This PR follows #293 and moves the workaround to disable mssql telemetry from `entrypoint.sh` to `DockerFile`.

Thx !