### PR TITLE
Improve mssql backups

### DIFF
--- a/util/MsSql/backup-db.sh
+++ b/util/MsSql/backup-db.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
-# Delete backup files older than 30 days
-find /etc/bitwarden/mssql/backups/ -type f -name '*.BAK' -mindepth 1 -mtime +30 -delete
+# Backup timestamp
+export now=${1:-$(date +%Y%m%d_%H%M%S)}
 
 # Do a new backup
 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -i /backup-db.sql
+
+# Delete backup files older than 30 days
+grep -B1 "BACKUP DATABASE successfully" /var/opt/mssql/log/errorlog | grep -q _$now.BAK &&
+find /etc/bitwarden/mssql/backups/ -mindepth 1 -type f -name '*.BAK' -mtime +32 -delete

--- a/util/MsSql/backup-db.sql
+++ b/util/MsSql/backup-db.sql
@@ -1,11 +1,8 @@
-DECLARE @TheDate NVARCHAR(20)
-SET @TheDate = REPLACE(CONVERT(VARCHAR, GETDATE(),101),'/','') + '_' +  REPLACE(CONVERT(VARCHAR, GETDATE(),108),':','')
-
 DECLARE @BackupFile varchar(100)
-SET @BackupFile = '/etc/bitwarden/mssql/backups/vault_FULL_'+ @TheDate + '.BAK'
+SET @BackupFile = '/etc/bitwarden/mssql/backups/vault_FULL_$(now).BAK'
 
 DECLARE @BackupName varchar(100)
-SET @BackupName = 'vault full backup for '+ @TheDate
+SET @BackupName = 'vault full backup for $(now)'
 
 DECLARE @BackupCommand NVARCHAR(1000)
 SET @BackupCommand = 'BACKUP DATABASE [vault] TO DISK = ''' + @BackupFile + ''' WITH INIT, NAME= ''' + @BackupName + ''', NOSKIP, NOFORMAT'

--- a/util/MsSql/crontab
+++ b/util/MsSql/crontab
@@ -1,3 +1,3 @@
-50 23 * * * bitwarden /backup-db.sh >> /var/log/cron.log 2>&1
+59 23 * * * bitwarden /backup-db.sh >> /var/log/cron.log 2>&1
 
 # An empty line is required at the end of this file for a valid cron file.

--- a/util/MsSql/crontab
+++ b/util/MsSql/crontab
@@ -1,3 +1,3 @@
-0 0 * * * bitwarden /backup-db.sh >> /var/log/cron.log 2>&1
+50 23 * * * bitwarden /backup-db.sh >> /var/log/cron.log 2>&1
 
 # An empty line is required at the end of this file for a valid cron file.


### PR DESCRIPTION
Hi,

This PR does several things :
- it modifies DB backup start time, so that they are named using the the day that has just gone ;
- it deletes old backups only if backup succeeded, for security reasons.

Additionally :
- it puts year first in backup timestamp ;
- it allows to pass the backup timestamp as a parameter, if script is launched manually for example ;
- it keeps a whole full month of backups.

Thank you !