### PR TITLE
Better handle update operations

### DIFF
--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -85,11 +85,10 @@ elif [ "$1" == "start" -o "$1" == "restart" ]
 then
     checkOutputDirExists
     $SCRIPTS_DIR/run.sh restart $OUTPUT $COREVERSION $WEBVERSION
-elif [ "$1" == "update" ]
+elif [ "$1" == "update" -o "$1" == "updateapp" ]
 then
     checkOutputDirExists
-    downloadRunFile
-    $SCRIPTS_DIR/run.sh update $OUTPUT $COREVERSION $WEBVERSION
+    $SCRIPTS_DIR/run.sh $1 $OUTPUT $COREVERSION $WEBVERSION
 elif [ "$1" == "updatedb" ]
 then
     checkOutputDirExists
@@ -100,6 +99,7 @@ then
     $SCRIPTS_DIR/run.sh stop $OUTPUT $COREVERSION $WEBVERSION
 elif [ "$1" == "updateself" ]
 then
+    downloadRunFile
     downloadSelf && echo "Updated self." && exit
 else
     echo "No command found."

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -137,8 +137,7 @@ function dockerComposePull() {
 function dockerPrune() {
     docker image prune -f
     # Perhaps we could prefer the following, to recover disk space after automatic update ?
-    # (product label would have to be added to images to avoid removing non-bitwarden images)
-    # docker image prune -f -a --filter="label=product=bitwarden"
+    # docker image prune -f -a --filter="label=com.bitwarden.product=bitwarden"
 }
 
 function updateLetsEncrypt() {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -179,7 +179,8 @@ function waitForDB() {
     i=0
     echo -n "Pausing for database to come online. Please wait..."
     # sqlagent.out is a binary file, sed then removes all non-ascii characters so that grep can correctly match
-    while ! sed 's/[^a-zA-Z ]//g' $OUTPUT_DIR/logs/mssql/sqlagent.out 2>/dev/null | tr '\n' ' ' | grep -iq "Waiting for SQL Server to start .* SQLServerAgent service successfully started"
+    while ! sed 's/[^a-zA-Z ]//g' $OUTPUT_DIR/logs/mssql/sqlagent.out 2>/dev/null | tr '\n' ' ' |
+            grep -iq "Waiting for SQL Server to start .* SQLServerAgent service successfully started"
     do
         sleep 2
         i=$(($i+2))

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -105,9 +105,9 @@ function install() {
 function dockerComposeUp() {
     if [ -f "${DOCKER_DIR}/docker-compose.override.yml" ]
     then
-        docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml up -d
+        docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml up -d $1
     else
-        docker-compose -f $DOCKER_DIR/docker-compose.yml up -d
+        docker-compose -f $DOCKER_DIR/docker-compose.yml up -d $1
     fi
 }
 
@@ -118,19 +118,27 @@ function dockerComposeDown() {
     else
         docker-compose -f $DOCKER_DIR/docker-compose.yml down
     fi
+    # Manually rotate previous sqlagent logfile so that waitForDB() will not match against it
+    if [ -f $OUTPUT_DIR/logs/mssql/sqlagent.out ]
+    then
+        mv $OUTPUT_DIR/logs/mssql/sqlagent.out $OUTPUT_DIR/logs/mssql/sqlagent.old
+    fi
 }
 
 function dockerComposePull() {
     if [ -f "${DOCKER_DIR}/docker-compose.override.yml" ]
     then
-        docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml pull
+        docker-compose -f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.override.yml pull $1
     else
-        docker-compose -f $DOCKER_DIR/docker-compose.yml pull
+        docker-compose -f $DOCKER_DIR/docker-compose.yml pull $1
     fi
 }
 
 function dockerPrune() {
     docker image prune -f
+    # Perhaps we could prefer the following, to recover disk space after automatic update ?
+    # (product label would have to be added to images to avoid removing non-bitwarden images)
+    # docker image prune -f -a --filter="label=product=bitwarden"
 }
 
 function updateLetsEncrypt() {
@@ -165,17 +173,20 @@ function printEnvironment() {
         dotnet Setup.dll -printenv 1 -os $OS -corev $COREVERSION -webv $WEBVERSION
 }
 
-function restart() {
-    dockerComposeDown
-    dockerComposePull
-    updateLetsEncrypt
-    dockerComposeUp
-    dockerPrune
-    printEnvironment
-}
-
 function pullSetup() {
     docker pull bitwarden/setup:$COREVERSION
+}
+
+function waitForDB() {
+    i=0
+    echo -n "Pausing for database to come online. Please wait..."
+    while ! sed 's/[^a-zA-Z ]//g' $OUTPUT_DIR/logs/mssql/sqlagent.out 2>/dev/null | tr '\n' ' ' | grep -iq "Waiting for SQL Server to start .* SQLServerAgent service successfully started"
+    do
+        sleep 2
+        i=$(($i+2))
+        echo -n .
+    done
+    echo " ($i s)"
 }
 
 # Commands
@@ -185,22 +196,39 @@ then
     install
 elif [ "$1" == "start" -o "$1" == "restart" ]
 then
-    restart
-elif [ "$1" == "pull" ]
-then
+    dockerComposeDown
     dockerComposePull
+    updateLetsEncrypt
+    dockerComposeUp mssql
+    waitForDB
+    dockerComposeUp
+    printEnvironment
 elif [ "$1" == "stop" ]
 then
     dockerComposeDown
+elif [ "$1" == "updateapp" ]
+then
+    dockerComposeDown
+    update
+    dockerComposePull
+    updateLetsEncrypt
 elif [ "$1" == "updatedb" ]
 then
+    dockerComposeDown
+    dockerComposePull mssql
+    dockerComposeUp mssql
+    waitForDB
     updateDatabase
 elif [ "$1" == "update" ]
 then
     dockerComposeDown
     update
-    restart
-    echo "Pausing 60 seconds for database to come online. Please wait..."
-    sleep 60
+    dockerComposePull
+    updateLetsEncrypt
+    dockerComposeUp mssql
+    waitForDB
     updateDatabase
+    dockerComposeUp
+    dockerPrune
+    printEnvironment
 fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -179,6 +179,7 @@ function pullSetup() {
 function waitForDB() {
     i=0
     echo -n "Pausing for database to come online. Please wait..."
+    # sqlagent.out is a binary file, sed then removes all non-ascii characters so that grep can correctly match
     while ! sed 's/[^a-zA-Z ]//g' $OUTPUT_DIR/logs/mssql/sqlagent.out 2>/dev/null | tr '\n' ' ' | grep -iq "Waiting for SQL Server to start .* SQLServerAgent service successfully started"
     do
         sleep 2

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -135,9 +135,8 @@ function dockerComposePull() {
 }
 
 function dockerPrune() {
-    docker image prune -f
-    # Perhaps we could prefer the following, to recover disk space after automatic update ?
-    # docker image prune -f -a --filter="label=com.bitwarden.product=bitwarden"
+    docker image prune -f --filter="label=com.bitwarden.product=bitwarden"
+    # Perhaps we could add "-a", to recover disk space after automatic update ?
 }
 
 function updateLetsEncrypt() {


### PR DESCRIPTION
Hi,

This PR allows to better handle update operations.

1.
It prevents users from being able to connect to the application when it has just been updated, but before database update completed.
For this, after the application has been switched off and updated, only the mssql container is restarted, for the database to be updated. Then, the other containers are restarted.

2.
Also, update procedure now properly waits for database to be up and running before proceeding, thus avoiding error like this :
```
Database is in script upgrade mode. Trying again (attempt #3)...
Migrating database.

Unhandled Exception: System.Data.SqlClient.SqlException: Login failed for user 'sa'. Reason: Server is in script upgrade mode. Only administrator can connect at this time.
   at Bit.Setup.Program.MigrateDatabase(Int32 attempt) in /Users/kyle/Projects/bitwarden/core/util/Setup/Program.cs:line 284
   at Bit.Setup.Program.MigrateDatabase(Int32 attempt) in /Users/kyle/Projects/bitwarden/core/util/Setup/Program.cs:line 280
   at Bit.Setup.Program.MigrateDatabase(Int32 attempt) in /Users/kyle/Projects/bitwarden/core/util/Setup/Program.cs:line 280
   at Bit.Setup.Program.Main(String[] args) in /Users/kyle/Projects/bitwarden/core/util/Setup/Program.cs:line 57
```

Start procedure also properly waits for database to be up and running before starting the other containers.
Time for database to come online is also printed, for info purpose.

3.
While here, as we already have an `updatedb` operation which update the database only, let's add an `updateapp` operation which update the application only. We may require it if we want to update the application without restarting it just after (which update does). Of course it then requires to proceed with `updatedb` and `start`.

4.
Pruning is now done on Bitwarden images only, now that images have a label (#305).
This solves [this community bug report](https://community.bitwarden.com/t/installing-bitwarden-into-an-existing-docker-server/1172).
I also added [a note](https://github.com/bitwarden/core/pull/302/files#diff-dcd8a73331aba627440c247763086b99R139) that we could perhaps add `-a` to `docker image prune` to recover disk space during "automatic" update (`update` operation). Perhaps this was the intended behavior ?

5.
Finally, merging this PR would possibly require a little doc update :
https://help.bitwarden.com/article/install-on-premise/
Proper installation procedure would now rather be :
```
./bitwarden.sh install
./bitwarden.sh updatedb
./bitwarden.sh start
```

Thank you 👍 