### PR TITLE
Add a bitwarden label to docker images

### DIFF
--- a/src/Admin/Dockerfile
+++ b/src/Admin/Dockerfile
@@ -1,6 +1,6 @@
 FROM microsoft/aspnetcore:2.0.6
 
-LABEL product="bitwarden"
+LABEL com.bitwarden.product="bitwarden"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/src/Admin/Dockerfile
+++ b/src/Admin/Dockerfile
@@ -1,5 +1,7 @@
 FROM microsoft/aspnetcore:2.0.6
 
+LABEL product="bitwarden"
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         gosu \

--- a/src/Api/Dockerfile
+++ b/src/Api/Dockerfile
@@ -1,5 +1,7 @@
 FROM microsoft/aspnetcore:2.0.6
 
+LABEL product="bitwarden"
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         cron \

--- a/src/Api/Dockerfile
+++ b/src/Api/Dockerfile
@@ -1,6 +1,6 @@
 FROM microsoft/aspnetcore:2.0.6
 
-LABEL product="bitwarden"
+LABEL com.bitwarden.product="bitwarden"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/src/Icons/Dockerfile
+++ b/src/Icons/Dockerfile
@@ -1,6 +1,6 @@
 FROM microsoft/aspnetcore:2.0.6
 
-LABEL product="bitwarden"
+LABEL com.bitwarden.product="bitwarden"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/src/Icons/Dockerfile
+++ b/src/Icons/Dockerfile
@@ -1,5 +1,7 @@
 FROM microsoft/aspnetcore:2.0.6
 
+LABEL product="bitwarden"
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         gosu \

--- a/src/Identity/Dockerfile
+++ b/src/Identity/Dockerfile
@@ -1,6 +1,6 @@
 FROM microsoft/aspnetcore:2.0.6
 
-LABEL product="bitwarden"
+LABEL com.bitwarden.product="bitwarden"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/src/Identity/Dockerfile
+++ b/src/Identity/Dockerfile
@@ -1,5 +1,7 @@
 FROM microsoft/aspnetcore:2.0.6
 
+LABEL product="bitwarden"
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         gosu \

--- a/util/Attachments/Dockerfile
+++ b/util/Attachments/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitwarden/server
 
-LABEL product="bitwarden"
+LABEL com.bitwarden.product="bitwarden"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/util/Attachments/Dockerfile
+++ b/util/Attachments/Dockerfile
@@ -1,5 +1,7 @@
 FROM bitwarden/server
 
+LABEL product="bitwarden"
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         gosu \

--- a/util/MsSql/Dockerfile
+++ b/util/MsSql/Dockerfile
@@ -1,5 +1,7 @@
 FROM microsoft/mssql-server-linux:2017-CU7
 
+LABEL product="bitwarden"
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         cron \

--- a/util/MsSql/Dockerfile
+++ b/util/MsSql/Dockerfile
@@ -1,6 +1,6 @@
 FROM microsoft/mssql-server-linux:2017-CU7
 
-LABEL product="bitwarden"
+LABEL com.bitwarden.product="bitwarden"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/util/Nginx/Dockerfile
+++ b/util/Nginx/Dockerfile
@@ -1,5 +1,7 @@
 FROM nginx:1.12
 
+LABEL product="bitwarden"
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         gosu \

--- a/util/Nginx/Dockerfile
+++ b/util/Nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.12
 
-LABEL product="bitwarden"
+LABEL com.bitwarden.product="bitwarden"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/util/Server/Dockerfile
+++ b/util/Server/Dockerfile
@@ -1,2 +1,5 @@
 FROM microsoft/aspnetcore:2.0.6
+
+LABEL product="bitwarden"
+
 COPY obj/Docker/publish /bitwarden_server

--- a/util/Server/Dockerfile
+++ b/util/Server/Dockerfile
@@ -1,5 +1,5 @@
 FROM microsoft/aspnetcore:2.0.6
 
-LABEL product="bitwarden"
+LABEL com.bitwarden.product="bitwarden"
 
 COPY obj/Docker/publish /bitwarden_server

--- a/util/Setup/Dockerfile
+++ b/util/Setup/Dockerfile
@@ -1,5 +1,7 @@
 FROM microsoft/dotnet:2.0.6-runtime
 
+LABEL product="bitwarden"
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         openssl \

--- a/util/Setup/Dockerfile
+++ b/util/Setup/Dockerfile
@@ -1,6 +1,6 @@
 FROM microsoft/dotnet:2.0.6-runtime
 
-LABEL product="bitwarden"
+LABEL com.bitwarden.product="bitwarden"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Hi,

This PR adds a label to each docker image.
This could help in some situations, such as with `docker image prune`, as explained in #302 :
https://github.com/bitwarden/core/pull/302/files#diff-dcd8a73331aba627440c247763086b99R139

Thank you 👍 