### PR TITLE
 Declare our own Compose project name

### DIFF
--- a/scripts/bitwarden.sh
+++ b/scripts/bitwarden.sh
@@ -48,6 +48,12 @@ function downloadSelf() {
 }
 
 function downloadRunFile() {
+    # docker-compose project name has been introduced in a new run.sh script,
+    # so we need to stop an instance which could be running without a project name
+    if [ -f $SCRIPTS_DIR/run.sh ] && ! grep -q COMPOSE_PROJECT_NAME $SCRIPTS_DIR/run.sh
+    then
+        $SCRIPTS_DIR/run.sh stop $OUTPUT $COREVERSION $WEBVERSION
+    fi
     if [ ! -d "$SCRIPTS_DIR" ]
     then
         mkdir $SCRIPTS_DIR

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -8,6 +8,8 @@ NC='\033[0m' # No Color
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+export COMPOSE_PROJECT_NAME=bw_${DIR%/bwdata*}
+
 OUTPUT_DIR=".."
 if [ $# -gt 1 ]
 then


### PR DESCRIPTION
Hi,

This PR declares a unique docker-compose project name, thus avoiding to collide (and share same network etc...) with other projects (Bitwarden or not) running in the same docker host.

Project name is `bw_<path_to_project>`.
For example, if Bitwarden files are in `/home/vault/bwdata`, project name will be `bw_homevault`.

This then closes #266.

Of course, migrating to this new script in a running environment, we must take care to properly stop the current running instance which has been launched with the default project name. This PR handles this.

Thank you 👍 