### PR TITLE
added basic constraints configuration for self signed certificates

### DIFF
--- a/util/Setup/CertBuilder.cs
+++ b/util/Setup/CertBuilder.cs
@@ -32,7 +32,7 @@ namespace Bit.Setup
                         $"-keyout /bitwarden/ssl/self/{Domain}/private.key " +
                         $"-out /bitwarden/ssl/self/{Domain}/certificate.crt " +
                         $"-reqexts SAN -extensions SAN " +
-                        $"-config <(cat /usr/lib/ssl/openssl.cnf <(printf '[SAN]\nsubjectAltName=DNS:{Domain}')) " +
+                        $"-config <(cat /usr/lib/ssl/openssl.cnf <(printf '[SAN]\nsubjectAltName=DNS:{Domain}\nbasicConstraints=CA:true')) " +
                         $"-subj \"/C=US/ST=Florida/L=Jacksonville/O=8bit Solutions LLC/OU=Bitwarden/CN={Domain}\"");
                 }
             }


### PR DESCRIPTION
**Issue:** The self signed certificate that the installer creates isn't valid on iOS. After importing, it doesn't show up as an option under General -> About -> Certificate Trust Settings. 

 However, manually running the same openssl command that the installer uses does work. After comparing the two certificates, the major difference between the two is that the working certificate includes the basic constraint CA = true. This is actually in the default openssl.cnf that the installer uses; however, the way that the installer adds the subjectAltName seems to override and remove the basic constraint. 

**How to reproduce:** On macOS, you can import the certificate and it should look like this: 
![macos certificate with constraint](https://user-images.githubusercontent.com/1091342/43031080-9c23bdee-8c68-11e8-9ac4-e1afb060e841.png)

The current certificate looks like this:
![macos certificate without constraint](https://user-images.githubusercontent.com/1091342/43031083-abff40c6-8c68-11e8-8b94-c2177d897bd9.png)

**Solution:** Simply passing in the basic constraint after the subjectAltName seems to work. Both appear in the final certificate. 

It's worth mentioning that in [v1.1.1 of OpenSSL added a new req option](https://github.com/openssl/openssl/commit/bfa470a4f64313651a35571883e235d3335054eb) that will make passing in the subjectAltName a lot easier. Right now you'd have to compile v1.1.1 yourself which seems like overkill.

**Why?** I run a self hosted instance on my home unRaid server on a Debian VM. My ISP blocks port 80 so letsencrypt isnt an option (or is significantly more work). 

I have only been able to test this on iOS, macOS, and ChromeOS. I haven't tested it on Android but I suspect itll work the same. I don't have a thorough understanding of what the basic constraint is actually doing, so I could be wrong here, but this seems to fix the issue I was having. 