### PR TITLE
Only prune our own images

### DIFF
--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -88,7 +88,7 @@ function Docker-Compose-Pull {
 }
 
 function Docker-Prune {
-    docker image prune -f
+    docker image prune -f --filter="label=com.bitwarden.product=bitwarden"
 }
 
 function Update-Lets-Encrypt {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -130,7 +130,8 @@ function dockerComposePull() {
 }
 
 function dockerPrune() {
-    docker image prune -f
+    docker image prune -f --filter="label=com.bitwarden.product=bitwarden"
+    # Perhaps we could add "-a", to recover disk space after automatic update ?
 }
 
 function updateLetsEncrypt() {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -131,7 +131,6 @@ function dockerComposePull() {
 
 function dockerPrune() {
     docker image prune -f --filter="label=com.bitwarden.product=bitwarden"
-    # Perhaps we could add "-a", to recover disk space after automatic update ?
 }
 
 function updateLetsEncrypt() {


### PR DESCRIPTION
Hi,

This PR makes sure pruning is done on Bitwarden images only, now that images have a label (#305).
This solves [this community bug report](https://community.bitwarden.com/t/installing-bitwarden-into-an-existing-docker-server/1172).
Perhaps we could add `-a` to `docker image prune` to recover disk space. Perhaps this was the intended behavior ?

Thank you 👍 