### PR TITLE
certbot email input error

### DIFF
--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -34,8 +34,8 @@ function Install() {
     
         if ($letsEncrypt -eq "y") {
             Write-Host "(!) " -f cyan -nonewline
-            [string]$email = $( Read-Host "Enter your email address (Let's Encrypt will send you certificate " +
-                "expiration reminders)" )
+            [string]$email = $( Read-Host ("Enter your email address (Let's Encrypt will send you certificate " +
+                "expiration reminders)") )
             echo ""
     
             $letsEncryptPath = "${outputDir}/letsencrypt"


### PR DESCRIPTION
when asked for an email address during certbot install, the given email address gets  joined with  the text "expiration reminders)". Thus cerbot install will fail.
Fixed the issue by setting suitable brackets.