### PR TITLE
Set Compose HTTP Timeout

### DIFF
--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -77,6 +77,7 @@ function Docker-Compose-Files {
     else {
         $env:COMPOSE_FILE = "${dockerDir}\docker-compose.yml"
     }
+    $env:COMPOSE_HTTP_TIMEOUT = "300"
 }
 
 function Docker-Prune {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -120,6 +120,7 @@ function dockerComposeFiles() {
     else
         export COMPOSE_FILE="$DOCKER_DIR/docker-compose.yml"
     fi
+    export COMPOSE_HTTP_TIMEOUT="300"
 }
 
 function dockerPrune() {


### PR DESCRIPTION
Set the COMPOSE_HTTP_TIMEOUT environment variable.  The default 60 seconds is too low when using Bitwarden inside of an LXC container.  This increase allows Bitwarden to be more easily containerized.