### PR TITLE
adds EXPOSE 8080 to Dockerfile to be coherent to nginx default config

### DIFF
--- a/util/Nginx/Dockerfile
+++ b/util/Nginx/Dockerfile
@@ -15,6 +15,7 @@ COPY security-headers-ssl.conf /etc/nginx
 COPY entrypoint.sh /
 
 EXPOSE 8080
+EXPOSE 8443
 
 RUN chmod +x /entrypoint.sh
 

--- a/util/Nginx/Dockerfile
+++ b/util/Nginx/Dockerfile
@@ -13,6 +13,9 @@ COPY mime.types /etc/nginx
 COPY security-headers.conf /etc/nginx
 COPY security-headers-ssl.conf /etc/nginx
 COPY entrypoint.sh /
+
+EXPOSE 8080
+
 RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
nginx runs as unprivileged user "bitwarden".

the nginx template https://github.com/bitwarden/core/blob/master/util/Setup/Templates/NginxConfig.hbs has hardcoded "8080" as portnumber.

the original nginx dockerfile https://github.com/nginxinc/docker-nginx/blob/f4d30145c60c433966df96f618d78513fee9d322/mainline/stretch/Dockerfile exposes port 80, but the bitwarden-nginx-config-template uses 8080 to be able to run nginx as unprivileged user.

however, 8080 is not added as exposed port. that makes service-discovery hard.
e.g. https://github.com/jwilder/docker-gen is not compatible per default if nginx listenes to a port that is not exposed in the dockerfile.